### PR TITLE
BUG: correct exit method for `python -m nonos`

### DIFF
--- a/src/nonos/__main__.py
+++ b/src/nonos/__main__.py
@@ -1,4 +1,6 @@
+import sys
+
 from nonos.main import main
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())


### PR DESCRIPTION
`exit`, despite broad availability in REPLs (including the default one), isn't a built-in function.