### PR TITLE
BUG: fixup undefined names in dunder all

### DIFF
--- a/src/nonos/api/__init__.py
+++ b/src/nonos/api/__init__.py
@@ -2,7 +2,6 @@ __all__ = [
     "GasDataSet",
     "GasField",
     "NonosLick",
-    "Parameters",
     "Plotable",
     "compute",
     "file_analysis",
@@ -10,7 +9,6 @@ __all__ = [
     "find_nearest",
     "from_data",
     "from_file",
-    "planet_analysis",
 ]
 from .analysis import GasDataSet, GasField, Plotable
 from .satellite import NonosLick, compute, file_analysis, from_data, from_file


### PR DESCRIPTION
Immediate follow up to #463
For some reason ruff doesn't seem to detect this, even though [the corresponding rule](https://docs.astral.sh/ruff/rules/undefined-export/) is enabled.