### PR TITLE
MNT: refine pre-commit config for prek compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
   - id: debug-statements
   - id: check-merge-conflict
   - id: trailing-whitespace
+    exclude: (\.dat|\.vtk)$
   - id: end-of-file-fixer
   - id: check-toml
 


### PR DESCRIPTION
playing around with https://github.com/j178/prek, this is the only change necessary to make it work on this repo